### PR TITLE
Fallback to `os.tmpdir()` if no `TMPDIR` set

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { spawn } from "child_process";
 import { existsSync } from "fs";
 import { type Socket, connect } from "net";
+import os from "os";
 import { join } from "path";
 import {
 	ExtensionContext,
@@ -27,7 +28,8 @@ function resolveBiomeBin(): string {
 }
 
 async function getSocketPath(command: string): Promise<string> {
-	const tmpdir = (await workspace.nvim.eval("$TMPDIR")) as string;
+	const tmpdir =
+		(await workspace.nvim.eval("$TMPDIR")) || (os.tmpdir() as string);
 	const child = spawn(command, ["__print_socket"], {
 		stdio: "pipe",
 		shell: true,


### PR DESCRIPTION
Fixes #11

# Summary

Running coc-biome will create files in each directory a file is opened in:

- `biome-logs/`
- `biome-socket-1.4.1`

Versions: vim 9.0, as of biome 1.4.1, 

# Changes

If no [`TMPDIR`](https://en.wikipedia.org/wiki/TMPDIR) set, default to [`os.tmpdir()`](https://nodejs.org/api/os.html#ostmpdir).

Safe default / fallback, noop for users that already have a `TMPDIR` in their shell.

On WSL 2 w/ Ubuntu 23.10, this will output to `/tmp/biome-logs/` and `/tmp/biome-socket-1.4.1`, instead of creating a new socket and log directory relatively in each file's directory upon connecting to the language server.